### PR TITLE
latest improvements to jekyll-hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstal

--- a/config.py
+++ b/config.py
@@ -17,6 +17,8 @@ SMTP_SERVER = 'someserver.com'
 # disable scripts.
 SCRIPT_DIR = 'scripts'
 
+# branches on whose pushes we should react
+LISTEN_BRANCHES=('refs/heads/pages-source',)
 
 ###################
 # override defaults with local values, if any

--- a/config.py
+++ b/config.py
@@ -1,0 +1,27 @@
+# port to listen to
+PORT=5836
+
+# directory to log github webhook events to. Set LOG_DIR = None to
+# disable event logging.
+LOG_DIR='events'
+
+# sender and receiver for email notifications. Set EMAIL_RECEIVER =
+# None to disable email notifications.
+#
+# Please define these again in config_site.py
+EMAIL_SENDER = 'nobody@nothing.com'
+EMAIL_RECEIVER = 'nobody@nothing.com'
+SMTP_SERVER = 'someserver.com'
+
+# directory where to run scripts from. Set SCRIPT_DIR = None to
+# disable scripts.
+SCRIPT_DIR = 'scripts'
+
+
+###################
+# override defaults with local values, if any
+try:
+    from config_site import *
+except:
+    pass
+

--- a/jekyllhook.py
+++ b/jekyllhook.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 from flask import Flask
 from flask import request
 
-from config import PORT, LOG_DIR, EMAIL_SENDER, EMAIL_RECEIVER, SCRIPT_DIR, SMTP_SERVER
+from config import PORT, LOG_DIR, EMAIL_SENDER, EMAIL_RECEIVER, SCRIPT_DIR, SMTP_SERVER, LISTEN_BRANCHES
 
 # Warning: never leave DEBUG = True when deploying: this flag is
 # propagated to Flask app debug, which can allow for arbitrary code
@@ -119,6 +119,11 @@ def run_scripts(directory=SCRIPT_DIR):
 @app.route('/', methods=['POST'])
 def event():
     data = load_json(request.data)
+
+    if data["ref"] not in LISTEN_BRANCHES:
+        #This is probably the gh-pages push resulting from the previous run of this script, ignore
+        logging.info("Ignoring push on branch %s"%str(data["ref"]))
+        return "OK"
     
     fn = log_event(pretty_print_json(data))
 

--- a/jekyllhook.py
+++ b/jekyllhook.py
@@ -12,21 +12,7 @@ from email.mime.text import MIMEText
 from flask import Flask
 from flask import request
 
-# port to listen to
-PORT = 5836
-
-# directory to log github webhook events to. Set LOG_DIR = None to
-# disable event logging.
-LOG_DIR='events'
-
-# sender and receiver for email notifications. Set EMAIL_RECEIVER =
-# None to disable email notifications.
-EMAIL_SENDER = 'sampo.pyysalo@gmail.com'
-EMAIL_RECEIVER = 'sampo.pyysalo@gmail.com'
-
-# directory where to run scripts from. Set SCRIPT_DIR = None to
-# disable scripts.
-SCRIPT_DIR = 'scripts'
+from config import PORT, LOG_DIR, EMAIL_SENDER, EMAIL_RECEIVER, SCRIPT_DIR
 
 # Warning: never leave DEBUG = True when deploying: this flag is
 # propagated to Flask app debug, which can allow for arbitrary code
@@ -75,7 +61,7 @@ def mail_file(fn, subject, sender=EMAIL_SENDER, receiver=EMAIL_RECEIVER):
     msg['From'] = sender
     msg['To'] = receiver
 
-    s = smtplib.SMTP('localhost')
+    s = smtplib.SMTP(SMTP_SERVER)
     s.sendmail(sender, [receiver], msg.as_string())
     s.quit()
 
@@ -136,9 +122,9 @@ def event():
     
     fn = log_event(pretty_print_json(data))
 
-    send_email(fn, data)
-
     run_scripts()
+
+    send_email(fn, data)
 
     return "OK"
 

--- a/jekyllhook.py
+++ b/jekyllhook.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 from flask import Flask
 from flask import request
 
-from config import PORT, LOG_DIR, EMAIL_SENDER, EMAIL_RECEIVER, SCRIPT_DIR
+from config import PORT, LOG_DIR, EMAIL_SENDER, EMAIL_RECEIVER, SCRIPT_DIR, SMTP_SERVER
 
 # Warning: never leave DEBUG = True when deploying: this flag is
 # propagated to Flask app debug, which can allow for arbitrary code

--- a/jekyllhook.py
+++ b/jekyllhook.py
@@ -14,6 +14,12 @@ from flask import request
 
 from config import PORT, LOG_DIR, EMAIL_SENDER, EMAIL_RECEIVER, SCRIPT_DIR, SMTP_SERVER, LISTEN_BRANCHES
 
+
+### CONFIG
+# General config is in config.py
+# local values (email addresses and smtp server): create config_site.py and set them there. Don't push this file into git.
+
+
 # Warning: never leave DEBUG = True when deploying: this flag is
 # propagated to Flask app debug, which can allow for arbitrary code
 # execution.

--- a/scripts/010-deploy.sh
+++ b/scripts/010-deploy.sh
@@ -21,7 +21,9 @@ cd $SOURCE_REPO
 git pull
 
 # build site (ends up in _site)
-jekyll build
+
+## Note that arguments of this script are passed to jekyll, this is used to call --full-rebuild
+jekyll build $*
 # --full-rebuild
 #/var/lib/gems/2.0.0/gems/jekyll-2.5.3/bin/jekyll build
 

--- a/scripts/010-deploy.sh
+++ b/scripts/010-deploy.sh
@@ -13,15 +13,16 @@ SOURCE_BRANCH='pages-source'
 TARGET_REPO='target'
 TARGET_BRANCH='gh-pages'
 
-TMP_DIR='_tmp_site_copy'
+TMP_DIR=$(realpath $(mktemp -d --tmpdir=.))
 
 # pull source
 cd $SOURCE_REPO
-git checkout $SOURCE_BRANCH
+#git checkout $SOURCE_BRANCH
 git pull
 
 # build site (ends up in _site)
-jekyll build
+#jekyll build
+/var/lib/gems/2.0.0/gems/jekyll-2.5.3/bin/jekyll build
 
 # copy site to temporary directory
 cd -
@@ -30,7 +31,7 @@ cp -R $SOURCE_REPO/_site $TMP_DIR
 
 # switch to target repo and clear
 cd $TARGET_REPO
-git checkout $TARGET_BRANCH
+#git checkout $TARGET_BRANCH
 rm -rf *
 
 # copy in and remove temporary data

--- a/scripts/010-deploy.sh
+++ b/scripts/010-deploy.sh
@@ -21,8 +21,9 @@ cd $SOURCE_REPO
 git pull
 
 # build site (ends up in _site)
-#jekyll build
-/var/lib/gems/2.0.0/gems/jekyll-2.5.3/bin/jekyll build
+jekyll build
+# --full-rebuild
+#/var/lib/gems/2.0.0/gems/jekyll-2.5.3/bin/jekyll build
 
 # copy site to temporary directory
 cd -


### PR DESCRIPTION
Sorry should have structured this better. Anyway, these commits implement:

1) Skipping pushes to gh-pages so that the generation does not run twice
2) Local config of the email server. Please read `config.py` to create the local config
3) `--full-rebuild` for added/removed files
4) Commented-out branch checkout in the 010-deploy script and uses real temporary directory naming so that concurrent requests don't step on each others' toes. (untested)
5) .gitignore

This is the code as it currently runs on epsilon.
